### PR TITLE
fix: get brazil location timezone instead UTC

### DIFF
--- a/handlers/messages/helpers.go
+++ b/handlers/messages/helpers.go
@@ -152,3 +152,8 @@ func replyMessage(m *discordgo.MessageCreate, s *discordgo.Session, gifUrl strin
 	_, err := s.ChannelMessageSendComplex(m.ChannelID, message)
 	return err
 }
+
+func getTimeNow() time.Time {
+	location, _ := time.LoadLocation("America/Sao_Paulo")
+	return time.Now().In(location)
+}

--- a/handlers/messages/sunday.go
+++ b/handlers/messages/sunday.go
@@ -25,7 +25,8 @@ func SundayHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	var gif GTenorMinimalReturn
 	var gifUrl string
 
-	switch time.Now().Weekday() {
+	timeNow := getTimeNow()
+	switch timeNow.Weekday() {
 	case time.Sunday:
 		content = "É hoje... Ele chegou..."
 		gif = getRandomGif("o malvado")


### PR DESCRIPTION
Closes issue #5 

# What changes

- Consider the Brazilian timezone for handling the "Sunday Night" messages

# Impact

- "Sunday Night" messages handler

# Evidencies

![image](https://github.com/user-attachments/assets/c4277826-247e-4371-9caf-d6c3ca2c1db5)

![image](https://github.com/user-attachments/assets/28a550f0-3ae8-4832-8142-2b182718b6ca)

